### PR TITLE
Add setup for mybinder.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ this should be easy to set up in a conda env: ``conda create -n covid python=3.7
 
 Author: Thomas Lecocq @seismotom
 
+Run it interactively on [mybinder.org](https://mybinder.org/v2/gh/ThomasLecocq/SeismoRMS/master)
+
 
 ## Example:
 The following data shows the effect of the Social Distancing measures from the

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: SeismoRMS
+channels:
+  - conda-forge
+dependencies:
+  - python =3.7
+  - obspy >=1.2.0
+  - pandas


### PR DESCRIPTION
Makes it runnable interactively on mybinder.org via link in README.md (first time opening it on mybinder will take pretty long -- conda install etc -- but after that the docker images are cached and start up fast)

(I'd also recommend adding `%matplotlib nbagg` as first line in notebook, figures somehow get bigger then though, so especially width would have to be reduced)