### PR TITLE
Resolve cell errors with tick formatter and failure when there is no tshift

### DIFF
--- a/seismosocialdistancing.py
+++ b/seismosocialdistancing.py
@@ -603,6 +603,7 @@ def clock24_plot_commons(ax,unit='nm'):
     # Set the circumference labels
     ax.set_xticks(np.linspace(0, 2*np.pi, 24, endpoint=False))
     ax.set_xticklabels(["%i h"%i for i in range(24)], fontsize=8)
+    ax.set_yticks(ax.get_yticks())
     ax.set_yticklabels(["%.2g %s" %(i,unit) for i in ax.get_yticks()], fontsize=7)
     ax.yaxis.set_tick_params(labelsize=8)
     ax.set_rlabel_position(0)

--- a/seismosocialdistancing.py
+++ b/seismosocialdistancing.py
@@ -9,6 +9,9 @@ import pandas as pd
 import numpy as np
 from obspy import UTCDateTime
 
+# For logo
+import urllib.request
+
 # For pqlx
 import subprocess,sys
 
@@ -723,9 +726,11 @@ def plot(displacement_RMS,
             
             for o in data:
                 rs = data[o].copy().between_time("6:00", "16:00")
-                rs = rs.resample("1D" ).median().tshift(12, "H")
+                rs = rs.resample("1D" ).median()
+                if hasattr(rs, 'tshift'):
+                    rs.tshift(12, "H")
                 plt.plot(rs.index, rs,
-                         label="$\overline{%s}$ (6h-16h)"%o)#, c='purple')
+                    label="$\overline{%s}$ (6h-16h)"%o)#, c='purple')
 
             
 

--- a/seismosocialdistancing.py
+++ b/seismosocialdistancing.py
@@ -9,9 +9,6 @@ import pandas as pd
 import numpy as np
 from obspy import UTCDateTime
 
-# For logo
-import urllib.request
-
 # For pqlx
 import subprocess,sys
 


### PR DESCRIPTION
`FixedFormatter` requires a fixed number of ticks. This is resolved by setting the values of the ticks before formatting them.

If there is no tshift in the plot, it fails. This is resolved by checking for the existence of the attribute itself first.